### PR TITLE
assets: Add Freifunk Braunschweig Site Description

### DIFF
--- a/app/src/main/assets/site/ffbs-next.json
+++ b/app/src/main/assets/site/ffbs-next.json
@@ -1,0 +1,7 @@
+{
+  "site_code": "ffbs-next",
+  "name": "Freifunk Braunschweig",
+  "short_name": "Freifunk Braunschweig",
+  "domain_names": {
+  }
+}


### PR DESCRIPTION
This adds the site description for Freifunk Braunschweig. With this change our site-code is resolved into our actual name.

Braunschweig does not have any domains, thus the domain_names map is empty.