### PR TITLE
Add | FFS from the current API State

### DIFF
--- a/app/src/main/assets/site/ffs.json
+++ b/app/src/main/assets/site/ffs.json
@@ -1,0 +1,7 @@
+{
+  "site_code": "ffs",
+  "name": "Freifunk Stuttgart",
+  "short_name": "ffs",
+  "domain_names": { "https://freifunk-stuttgart.de",
+  }
+}


### PR DESCRIPTION
Get Data "FFS" from the current [API](https://map.freifunk-stuttgart.de/json/FreifunkStuttgart-api.json).

## Current State
Even if you currently directly connected with a [Router](https://map.freifunk-stuttgart.de/#!/de/map/18d6c7f9e0e2), it doesn´t show up in the App. Maby this will fix it.

## Should do
Showing all "FFS" related Routers.