### PR TITLE
fix crash when updating scan results

### DIFF
--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -152,10 +152,8 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun updateScanResultList(wifiScanResults: List<WifiScanResult>) {
-        for (node in scanResultListModel.scanResults) {
-            if (node.lastSeen?.time!! < System.currentTimeMillis() - 60000) {
-                scanResultListModel.scanResults.remove(node)
-            }
+        scanResultListModel.scanResults.removeAll {
+            it.lastSeen?.time!! < System.currentTimeMillis() - 60000
         }
 
         /* Loop through new scan results */


### PR DESCRIPTION
The crash was caused as the for loop iterated over scanResults while calling remove() on the same list inside the loop body.

This can be easily reproduced by starting the app, let it scan, put it in the background for a few minutes, opening it again. It will crash then.