### PR TITLE
make wifi scanning consistent with WiFi throttling enabled

### DIFF
--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import net.freifunk.darmstadt.nodewhisperer.models.GluonNode
@@ -85,7 +86,7 @@ import java.io.FileNotFoundException
 
 class MainActivity : ComponentActivity() {
     val scanResultListModel = ScanResultListModel()
-    val wifiScanService = WifiScanService(this)
+    val wifiScanService = WifiScanService(this, lifecycleScope)
     val communityService = CommunityService(this)
     private val wifiScanReceiver = object : WifiScanServiceResultReceiver {
         override fun onScanResultUpdate(wifiScanResults: List<WifiScanResult>) {

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -3,17 +3,14 @@
 package net.freifunk.darmstadt.nodewhisperer
 
 import android.Manifest
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.net.wifi.WifiManager
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresPermission
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -33,8 +30,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -62,7 +59,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.CoroutineScope
@@ -79,7 +75,6 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.FileNotFoundException
-import java.lang.StringBuilder
 
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -46,10 +47,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -62,6 +67,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import net.freifunk.darmstadt.nodewhisperer.models.GluonNode
 import net.freifunk.darmstadt.nodewhisperer.models.ScanResultListModel
 import net.freifunk.darmstadt.nodewhisperer.models.WifiScanResult
@@ -395,17 +401,18 @@ fun activityDesign(
                     }
                 }
             ) { innerPadding ->
-                LazyColumn(
-                    modifier = Modifier
-                        .padding(innerPadding),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-
-                ) {
-                    scanResultsList.scanResults.let {
-                        itemsIndexed(scanResultsList.scanResults) { index, item ->
-                            ScanResultListElement(
-                                node = item
-                            )
+                Column(modifier = Modifier.padding(innerPadding)) {
+                    ScanStatusBar(wifiScanService)
+                    LazyColumn(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        scanResultsList.scanResults.let {
+                            itemsIndexed(scanResultsList.scanResults) { index, item ->
+                                ScanResultListElement(
+                                    node = item
+                                )
+                            }
                         }
                     }
                 }
@@ -544,6 +551,70 @@ fun NodeInfoDialogProperty(name: String, content: String) {
             text = content,
             textAlign = TextAlign.Start,
         )
+    }
+}
+
+@Composable
+fun ScanStatusBar(wifiScanService: WifiScanService) {
+    val isEnabled = wifiScanService.scanningEnabled.value
+    val lastTimestamp = wifiScanService.lastScanTimestamp.value
+    val barColor = MaterialTheme.colorScheme.secondary
+
+    if (!isEnabled) {
+        return
+    }
+
+    if (lastTimestamp == null) {
+        ScanStatusRow(
+            text = stringResource(R.string.scan_status_waiting),
+            color = barColor
+        )
+        return
+    }
+
+    var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000L)
+            now = System.currentTimeMillis()
+        }
+    }
+
+    val elapsedSec = ((now - lastTimestamp) / 1000).toInt()
+    val elapsedText = if (elapsedSec < 60) {
+        stringResource(R.string.scan_status_seconds, elapsedSec)
+    } else {
+        stringResource(R.string.scan_status_minutes, elapsedSec / 60)
+    }
+
+    ScanStatusRow(
+        text = stringResource(R.string.scan_status_last_scan, elapsedText),
+        color = barColor
+    )
+}
+
+@Composable
+fun ScanStatusRow(text: String, color: Color) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        LinearProgressIndicator(
+            modifier = Modifier.fillMaxWidth(),
+            color = color,
+            trackColor = color.copy(alpha = 0.3f)
+        )
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                modifier = Modifier.align(Alignment.CenterEnd),
+                text = text,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
     }
 }
 

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -592,27 +592,40 @@ fun ScanStatusBar(wifiScanService: WifiScanService) {
         else -> colorResource(R.color.red_500).copy(alpha = 0.3f)
     }
 
+    val throttleText = if (wifiScanService.scanThrottleEnabled.value) {
+        stringResource(R.string.wifi_scan_throttled)
+    } else {
+        null
+    }
+
     ScanStatusStripContent(
         text = stringResource(R.string.scan_status_last_scan, elapsedText),
-        color = stripColor
+        color = stripColor,
+        secondaryText = throttleText
     )
 }
 
 @Composable
-fun ScanStatusStripContent(text: String, color: Color) {
-    Row(
+fun ScanStatusStripContent(text: String, color: Color, secondaryText: String? = null) {
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(color)
             .padding(horizontal = 16.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = text,
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurface
         )
+        if (secondaryText != null) {
+            Text(
+                text = secondaryText,
+                style = MaterialTheme.typography.labelSmall,
+                color = colorResource(R.color.red_500)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -319,7 +319,7 @@ fun getIconForNodeStatus(node: GluonNode): ImageVector {
 @Composable
 fun activityDesign(
     activity: MainActivity,
-    wifiScanService: WifiScanService? = null,
+    wifiScanService: WifiScanService,
     scanResultsList: ScanResultListModel = ScanResultListModel()
 ) {
     NodeWhispererTheme {
@@ -373,13 +373,13 @@ fun activityDesign(
                     ExtendedFloatingActionButton(
                         onClick = {
                             if (activity.haveAllPermissions()) {
-                                toggleScanState(wifiScanService!!, scanResultsList)
-                            } else if (wifiScanService != null && !wifiScanService.scanningEnabled.value) {
+                                toggleScanState(wifiScanService, scanResultsList)
+                            } else if (!wifiScanService.scanningEnabled.value) {
                                 activity.permissionToast()
                             }
                         },
                         containerColor =
-                        if (wifiScanService!!.scanningEnabled.value)
+                        if (wifiScanService.scanningEnabled.value)
                             colorResource(R.color.red_500)
                         else
                             colorResource(R.color.green_500)
@@ -391,7 +391,7 @@ fun activityDesign(
                         )
                         Text(
                             text =
-                            if (wifiScanService!!.scanningEnabled.value)
+                            if (wifiScanService.scanningEnabled.value)
                                 stringResource(R.string.fab_scan_stop)
                             else
                                 stringResource(R.string.fab_scan_start),

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -11,6 +11,9 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -59,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -560,6 +564,7 @@ fun ScanStatusBar(wifiScanService: WifiScanService) {
     val isEnabled = wifiScanService.scanningEnabled.value
     val lastTimestamp = wifiScanService.lastScanTimestamp.value
     val barColor = MaterialTheme.colorScheme.secondary
+    val isThrottled = wifiScanService.scanThrottleEnabled.value
 
     if (!isEnabled) {
         return
@@ -568,7 +573,8 @@ fun ScanStatusBar(wifiScanService: WifiScanService) {
     if (lastTimestamp == null) {
         ScanStatusRow(
             text = stringResource(R.string.scan_status_waiting),
-            color = barColor
+            color = barColor,
+            isThrottled = isThrottled
         )
         return
     }
@@ -588,14 +594,18 @@ fun ScanStatusBar(wifiScanService: WifiScanService) {
         stringResource(R.string.scan_status_minutes, elapsedSec / 60)
     }
 
+    val progress: Float? = if (isThrottled) (elapsedSec / WifiScanService.THROTTLED_SCAN_INTERVAL_SEC.toFloat()).coerceIn(0f, 1f) else null
+
     ScanStatusRow(
         text = stringResource(R.string.scan_status_last_scan, elapsedText),
-        color = barColor
+        color = barColor,
+        isThrottled = isThrottled,
+        progress = progress
     )
 }
 
 @Composable
-fun ScanStatusRow(text: String, color: Color) {
+fun ScanStatusRow(text: String, color: Color, isThrottled: Boolean, progress: Float? = null) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -603,12 +613,49 @@ fun ScanStatusRow(text: String, color: Color) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        LinearProgressIndicator(
-            modifier = Modifier.fillMaxWidth(),
-            color = color,
-            trackColor = color.copy(alpha = 0.3f)
-        )
+        if (progress != null) {
+            val animatedProgress by animateFloatAsState(
+                targetValue = progress,
+                animationSpec = tween(durationMillis = 1000, easing = LinearEasing),
+                label = "scanStaleness"
+            )
+            LinearProgressIndicator(
+                progress = { animatedProgress },
+                modifier = Modifier.fillMaxWidth(),
+                color = color,
+                trackColor = color.copy(alpha = 0.3f),
+                drawStopIndicator = {}
+            )
+        } else {
+            LinearProgressIndicator(
+                modifier = Modifier.fillMaxWidth(),
+                color = color,
+                trackColor = color.copy(alpha = 0.3f)
+            )
+        }
         Box(modifier = Modifier.fillMaxWidth()) {
+            if (isThrottled) {
+                Row(
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    val iconSize = with(LocalDensity.current) {
+                        MaterialTheme.typography.labelSmall.fontSize.toDp()
+                    }
+                    Icon(
+                        modifier = Modifier.size(iconSize),
+                        imageVector = Icons.Default.Warning,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                    Text(
+                        text = stringResource(R.string.wifi_scan_throttled),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
             Text(
                 modifier = Modifier.align(Alignment.CenterEnd),
                 text = text,

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -49,10 +49,15 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -395,17 +400,18 @@ fun activityDesign(
                     }
                 }
             ) { innerPadding ->
-                LazyColumn(
-                    modifier = Modifier
-                        .padding(innerPadding),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-
-                ) {
-                    scanResultsList.scanResults.let {
-                        itemsIndexed(scanResultsList.scanResults) { index, item ->
-                            ScanResultListElement(
-                                node = item
-                            )
+                Column(modifier = Modifier.padding(innerPadding)) {
+                    ScanStatusBar(wifiScanService!!)
+                    LazyColumn(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        scanResultsList.scanResults.let {
+                            itemsIndexed(scanResultsList.scanResults) { index, item ->
+                                ScanResultListElement(
+                                    node = item
+                                )
+                            }
                         }
                     }
                 }
@@ -540,6 +546,72 @@ fun NodeInfoDialogProperty(name: String, content: String) {
         Text(
             text = content,
             textAlign = TextAlign.Start,
+        )
+    }
+}
+
+@Composable
+fun ScanStatusBar(wifiScanService: WifiScanService) {
+    val isEnabled = wifiScanService.scanningEnabled.value
+    val lastTimestamp = wifiScanService.lastScanTimestamp.value
+
+    if (!isEnabled) {
+        ScanStatusStripContent(
+            text = stringResource(R.string.scan_status_stopped),
+            color = MaterialTheme.colorScheme.surfaceVariant
+        )
+        return
+    }
+
+    if (lastTimestamp == null) {
+        ScanStatusStripContent(
+            text = stringResource(R.string.scan_status_waiting),
+            color = MaterialTheme.colorScheme.surfaceVariant
+        )
+        return
+    }
+
+    var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000L)
+            now = System.currentTimeMillis()
+        }
+    }
+
+    val elapsedSec = ((now - lastTimestamp) / 1000).toInt()
+    val elapsedText = if (elapsedSec < 60) {
+        stringResource(R.string.scan_status_seconds, elapsedSec)
+    } else {
+        stringResource(R.string.scan_status_minutes, elapsedSec / 60)
+    }
+
+    val stripColor = when {
+        elapsedSec < 20 -> colorResource(R.color.green_500).copy(alpha = 0.3f)
+        elapsedSec < 60 -> colorResource(R.color.yellow_500).copy(alpha = 0.3f)
+        else -> colorResource(R.color.red_500).copy(alpha = 0.3f)
+    }
+
+    ScanStatusStripContent(
+        text = stringResource(R.string.scan_status_last_scan, elapsedText),
+        color = stripColor
+    )
+}
+
+@Composable
+fun ScanStatusStripContent(text: String, color: Color) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color)
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface
         )
     }
 }

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
@@ -21,6 +21,7 @@ class WifiScanService(context: Context) {
 
     var scanningEnabled: MutableState<Boolean> = mutableStateOf(false)
     var scanningPaused: MutableState<Boolean> = mutableStateOf(false)
+    var lastScanTimestamp: MutableState<Long?> = mutableStateOf(null)
     val wifiScanReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             val success = intent.getBooleanExtra(WifiManager.EXTRA_RESULTS_UPDATED, false)
@@ -60,6 +61,7 @@ class WifiScanService(context: Context) {
         if (this.scanningPaused.value || !this.scanningEnabled.value)
             return
 
+        lastScanTimestamp.value = System.currentTimeMillis()
         wifiScanServiceResultReceiver?.onScanResultUpdate(wifiScanResults)
         startScanIteration()
     }
@@ -93,6 +95,7 @@ class WifiScanService(context: Context) {
 
         scanningEnabled.value = true
         scanningPaused.value = false
+        lastScanTimestamp.value = null
         startScanIteration()
     }
 
@@ -100,6 +103,7 @@ class WifiScanService(context: Context) {
         Log.d("WifiScanService", "Stop scanning")
         scanningEnabled.value = false
         scanningPaused.value = false
+        lastScanTimestamp.value = null
         if (receiverRegistered) {
             context.unregisterReceiver(wifiScanReceiver)
             receiverRegistered = false

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
@@ -21,6 +21,7 @@ class WifiScanService(context: Context) {
 
     var scanningEnabled: MutableState<Boolean> = mutableStateOf(false)
     var scanningPaused: MutableState<Boolean> = mutableStateOf(false)
+    var lastScanTimestamp: MutableState<Long?> = mutableStateOf(null)
     val wifiScanReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             val success = intent.getBooleanExtra(WifiManager.EXTRA_RESULTS_UPDATED, false)
@@ -60,6 +61,7 @@ class WifiScanService(context: Context) {
         if (this.scanningPaused.value || !this.scanningEnabled.value)
             return
 
+        lastScanTimestamp.value = System.currentTimeMillis()
         wifiScanServiceResultReceiver?.onScanResultUpdate(wifiScanResults)
         startScanIteration()
     }
@@ -92,6 +94,7 @@ class WifiScanService(context: Context) {
 
         scanningEnabled.value = true
         scanningPaused.value = false
+        lastScanTimestamp.value = null
         startScanIteration()
     }
 
@@ -99,6 +102,7 @@ class WifiScanService(context: Context) {
         Log.d("WifiScanService", "Stop scanning")
         scanningEnabled.value = false
         scanningPaused.value = false
+        lastScanTimestamp.value = null
         if (receiverRegistered) {
             context.unregisterReceiver(wifiScanReceiver)
             receiverRegistered = false

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
@@ -7,13 +7,22 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.net.wifi.WifiManager
+import android.os.Build
 import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.app.ActivityCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import net.freifunk.darmstadt.nodewhisperer.models.WifiScanResult
 
-class WifiScanService(context: Context) {
+class WifiScanService(context: Context, private val scope: CoroutineScope) {
+    companion object {
+        const val THROTTLED_SCAN_INTERVAL_SEC = 30
+    }
+
     private val context: Context = context
     var receiverRegistered: Boolean = false
     var scanning: Boolean = false
@@ -22,6 +31,8 @@ class WifiScanService(context: Context) {
     var scanningEnabled: MutableState<Boolean> = mutableStateOf(false)
     var scanningPaused: MutableState<Boolean> = mutableStateOf(false)
     var lastScanTimestamp: MutableState<Long?> = mutableStateOf(null)
+    var scanThrottleEnabled: MutableState<Boolean> = mutableStateOf(false)
+    private var scanJob: Job? = null
     val wifiScanReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             val success = intent.getBooleanExtra(WifiManager.EXTRA_RESULTS_UPDATED, false)
@@ -79,8 +90,24 @@ class WifiScanService(context: Context) {
         this.wifiScanServiceResultReceiver = null
     }
 
+    private fun checkThrottleEnabled() {
+        scanThrottleEnabled.value = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            getManager().isScanThrottleEnabled
+        } else {
+            true
+        }
+    }
+
     private fun startScanIteration() {
-        getManager().startScan()
+        scanJob?.cancel()
+        if (scanThrottleEnabled.value) {
+            scanJob = scope.launch {
+                delay(THROTTLED_SCAN_INTERVAL_SEC * 1000L)
+                getManager().startScan()
+            }
+        } else {
+            getManager().startScan()
+        }
     }
 
     fun startScanning() {
@@ -96,7 +123,8 @@ class WifiScanService(context: Context) {
         scanningEnabled.value = true
         scanningPaused.value = false
         lastScanTimestamp.value = null
-        startScanIteration()
+        checkThrottleEnabled()
+        getManager().startScan()
     }
 
     fun stopScanning() {
@@ -104,6 +132,7 @@ class WifiScanService(context: Context) {
         scanningEnabled.value = false
         scanningPaused.value = false
         lastScanTimestamp.value = null
+        scanJob?.cancel()
         if (receiverRegistered) {
             context.unregisterReceiver(wifiScanReceiver)
             receiverRegistered = false
@@ -113,11 +142,13 @@ class WifiScanService(context: Context) {
     fun pauseScanning() {
         Log.d("WifiScanService", "Pause scanning")
         scanningPaused.value = true
+        scanJob?.cancel()
     }
 
     fun resumeScanning() {
         Log.d("WifiScanService", "Resume scanning")
         scanningPaused.value = false
+        checkThrottleEnabled()
         startScanIteration()
     }
 }

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
@@ -7,6 +7,9 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -22,6 +25,8 @@ class WifiScanService(context: Context) {
     var scanningEnabled: MutableState<Boolean> = mutableStateOf(false)
     var scanningPaused: MutableState<Boolean> = mutableStateOf(false)
     var lastScanTimestamp: MutableState<Long?> = mutableStateOf(null)
+    var scanThrottleEnabled: MutableState<Boolean> = mutableStateOf(false)
+    private val handler = Handler(Looper.getMainLooper())
     val wifiScanReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             val success = intent.getBooleanExtra(WifiManager.EXTRA_RESULTS_UPDATED, false)
@@ -78,8 +83,21 @@ class WifiScanService(context: Context) {
         this.wifiScanServiceResultReceiver = null
     }
 
+    private fun checkThrottleEnabled() {
+        scanThrottleEnabled.value = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            getManager().isScanThrottleEnabled
+        } else {
+            true
+        }
+    }
+
     private fun startScanIteration() {
-        getManager().startScan()
+        handler.removeCallbacksAndMessages(null)
+        if (scanThrottleEnabled.value) {
+            handler.postDelayed({ getManager().startScan() }, 30_000L)
+        } else {
+            getManager().startScan()
+        }
     }
 
     fun startScanning() {
@@ -95,7 +113,8 @@ class WifiScanService(context: Context) {
         scanningEnabled.value = true
         scanningPaused.value = false
         lastScanTimestamp.value = null
-        startScanIteration()
+        checkThrottleEnabled()
+        getManager().startScan()
     }
 
     fun stopScanning() {
@@ -103,6 +122,7 @@ class WifiScanService(context: Context) {
         scanningEnabled.value = false
         scanningPaused.value = false
         lastScanTimestamp.value = null
+        handler.removeCallbacksAndMessages(null)
         if (receiverRegistered) {
             context.unregisterReceiver(wifiScanReceiver)
             receiverRegistered = false
@@ -112,11 +132,13 @@ class WifiScanService(context: Context) {
     fun pauseScanning() {
         Log.d("WifiScanService", "Pause scanning")
         scanningPaused.value = true
+        handler.removeCallbacksAndMessages(null)
     }
 
     fun resumeScanning() {
         Log.d("WifiScanService", "Resume scanning")
         scanningPaused.value = false
+        checkThrottleEnabled()
         startScanIteration()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,9 @@
     <string name="global_unknown">Unknown</string>
     <string name="url_help">https://github.com/freifunk-darmstadt/NodeMonitor/blob/master/docs/data-privacy.md</string>
     <string name="msg_permission_request">Bitte erteilen Sie die benötigten Berechtigungen</string>
+    <string name="scan_status_last_scan">Letzter Scan vor %s</string>
+    <string name="scan_status_stopped">Scan gestoppt</string>
+    <string name="scan_status_waiting">Warte auf Scan\u2026</string>
+    <string name="scan_status_seconds">%d Sek.</string>
+    <string name="scan_status_minutes">%d Min.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,5 @@
     <string name="scan_status_waiting">Warte auf Scan\u2026</string>
     <string name="scan_status_seconds">%d Sek.</string>
     <string name="scan_status_minutes">%d Min.</string>
+    <string name="wifi_scan_throttled">Wi-Fi Scan Drosselung des Systems aktiv</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,5 @@
     <string name="scan_status_waiting">Warte auf Scan\u2026</string>
     <string name="scan_status_seconds">%d Sek.</string>
     <string name="scan_status_minutes">%d Min.</string>
+    <string name="wifi_scan_throttled">Wi-Fi Scan Drosselung aktiv</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,8 @@
     <string name="global_unknown">Unknown</string>
     <string name="url_help">https://github.com/freifunk-darmstadt/NodeMonitor/blob/master/docs/data-privacy.md</string>
     <string name="msg_permission_request">Bitte erteilen Sie die benötigten Berechtigungen</string>
+    <string name="scan_status_last_scan">Letzter Scan vor %s</string>
+    <string name="scan_status_waiting">Warte auf Scan\u2026</string>
+    <string name="scan_status_seconds">%d Sek.</string>
+    <string name="scan_status_minutes">%d Min.</string>
 </resources>


### PR DESCRIPTION
I noticed that WiFi scanning was very inconsistent as my phone had wifi scan throttling enabled (can only be disabled via developer options).

So a scan every 1-2s means that it scans 4x times within ~4-8 seconds and then doesn't update the list for another 2 minutes before doing the next scan. The second commit changes to to scan every 30s if scan throttling is enabled, so it's evenly paced across the 2 minute window.
See https://developer.android.com/develop/connectivity/wifi/wifi-scan#wifi-scan-throttling

The commits here help with the problem:
1. they add an indicator of the last scan time
2. they slow scanning times if wifi throttling is active
3. they show an indicator if wifi scan throttling is active