### PR TITLE
fix: app leaks wifi intent receiver

### DIFF
--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -86,6 +86,12 @@ class MainActivity : ComponentActivity() {
     val scanResultListModel = ScanResultListModel()
     val wifiScanService = WifiScanService(this)
     val communityService = CommunityService(this)
+    private val wifiScanReceiver = object : WifiScanServiceResultReceiver {
+        override fun onScanResultUpdate(wifiScanResults: List<WifiScanResult>) {
+            Log.d("MainActivity", "Scan results updated {${wifiScanResults.size}}")
+            updateScanResultList(wifiScanResults)
+        }
+    }
 
     fun haveAllPermissions(): Boolean {
         return checkSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) == android.content.pm.PackageManager.PERMISSION_GRANTED &&
@@ -123,12 +129,7 @@ class MainActivity : ComponentActivity() {
             requestPermissionLauncher.launch(android.Manifest.permission.ACCESS_WIFI_STATE)
         }
 
-        wifiScanService.registerReceiver(object : WifiScanServiceResultReceiver {
-            override fun onScanResultUpdate(wifiScanResults: List<WifiScanResult>) {
-                Log.d("MainActivity", "Scan results updated {${wifiScanResults.size}}")
-                updateScanResultList(wifiScanResults)
-            }
-        })
+        wifiScanService.registerReceiver(wifiScanReceiver)
 
         if (!haveAllPermissions()) {
             permissionToast()
@@ -149,6 +150,11 @@ class MainActivity : ComponentActivity() {
         if (haveAllPermissions() && wifiScanService.scanningEnabled.value && wifiScanService.scanningPaused.value) {
             wifiScanService.resumeScanning()
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        wifiScanService.unregisterReceiver(wifiScanReceiver)
     }
 
     private fun updateScanResultList(wifiScanResults: List<WifiScanResult>) {

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
@@ -73,6 +73,7 @@ class WifiScanService(context: Context) {
     }
 
     fun unregisterReceiver(wifiScanServiceResultReceiver: WifiScanServiceResultReceiver) {
+        context.unregisterReceiver(wifiScanReceiver)
         this.wifiScanServiceResultReceiver = null
     }
 


### PR DESCRIPTION
If the `MainActivity` is destroyed, the wifi scan intent receiver is still running. That leads the app to crash, e.g. when changing the theme:

```
Activity net.freifunk.darmstadt.nodewhisperer.MainActivity has leaked IntentReceiver net.freifunk.darmstadt.nodewhisperer.services.WifiScanService$wifiScanReceiver$1@443d454 that was originally registered here. Are you missing a call to unregisterReceiver()?
                                                                                                    android.app.IntentReceiverLeaked: Activity net.freifunk.darmstadt.nodewhisperer.MainActivity has leaked IntentReceiver net.freifunk.darmstadt.nodewhisperer.services.WifiScanService$wifiScanReceiver$1@443d454 that was originally registered here. Are you missing a call to unregisterReceiver()?
                                                                                                    	at android.app.LoadedApk$ReceiverDispatcher.<init>(LoadedApk.java:1971)
                                                                                                    	at android.app.LoadedApk.getReceiverDispatcher(LoadedApk.java:1711)
                                                                                                    	at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1972)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1924)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1912)
                                                                                                    	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:793)
                                                                                                    	at net.freifunk.darmstadt.nodewhisperer.services.WifiScanService.startScanning(WifiScanService.kt:88)
                                                                                                    	at net.freifunk.darmstadt.nodewhisperer.MainActivityKt.toggleScanState(MainActivity.kt:265)
                                                                                                    	at net.freifunk.darmstadt.nodewhisperer.MainActivity.onCreate(MainActivity.kt:136)
                                                                                                    	at android.app.Activity.performCreate(Activity.java:9306)
                                                                                                    	at android.app.Activity.performCreate(Activity.java:9284)
                                                                                                    	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1548)
                                                                                                    	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4481)
                                                                                                    	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4700)
                                                                                                    	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:224)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:133)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:103)
                                                                                                    	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2962)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:132)
                                                                                                    	at android.os.Looper.dispatchMessage(Looper.java:333)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:263)
                                                                                                    	at android.os.Looper.loop(Looper.java:367)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:9299)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

This fixes it by just unregistering the receiver in `onDestroy`.

You can test this by changing the theme from light to dark while the app is running and see that the app doesn't crash.