### PR TITLE
Fix various color issues

### DIFF
--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -74,6 +74,7 @@ import net.freifunk.darmstadt.nodewhisperer.services.CommunityService
 import net.freifunk.darmstadt.nodewhisperer.services.NodeStatusService
 import net.freifunk.darmstadt.nodewhisperer.services.WifiScanService
 import net.freifunk.darmstadt.nodewhisperer.services.WifiScanServiceResultReceiver
+import net.freifunk.darmstadt.nodewhisperer.ui.theme.LocalCustomColorsPalette
 import net.freifunk.darmstadt.nodewhisperer.ui.theme.NodeWhispererTheme
 import org.json.JSONArray
 import org.json.JSONException
@@ -295,9 +296,9 @@ fun getSiteDomainString(node: GluonNode): String? {
 @Composable
 fun getColorForNodeStatus(node: GluonNode): Color {
     return when (NodeStatusService.getNodeStatus(node)) {
-        NodeStatus.OK -> colorResource(R.color.green_500)
-        NodeStatus.MESH_ONLY -> colorResource(R.color.yellow_500)
-        else -> colorResource(R.color.red_500)
+        NodeStatus.OK -> LocalCustomColorsPalette.current.successColor
+        NodeStatus.MESH_ONLY -> LocalCustomColorsPalette.current.warningColor
+        else -> MaterialTheme.colorScheme.errorContainer
     }
 }
 
@@ -374,9 +375,9 @@ fun activityDesign(
                         },
                         containerColor =
                         if (wifiScanService!!.scanningEnabled.value)
-                            colorResource(R.color.red_500)
+                            MaterialTheme.colorScheme.errorContainer
                         else
-                            colorResource(R.color.green_500)
+                            MaterialTheme.colorScheme.primary
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.wifi_find),

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresPermission
 import androidx.compose.foundation.background
@@ -100,6 +101,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
 
         setContent {
             activityDesign(this, wifiScanService, scanResultListModel)

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/MainActivity.kt
@@ -331,7 +331,8 @@ fun activityDesign(
                     CenterAlignedTopAppBar(
                         colors = topAppBarColors(
                             containerColor = MaterialTheme.colorScheme.primaryContainer,
-                            titleContentColor = MaterialTheme.colorScheme.primary,
+                            titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
                         ),
                         title = {
                             Text("Knoten")

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/ui/theme/Color.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/ui/theme/Color.kt
@@ -2,10 +2,16 @@ package net.freifunk.darmstadt.nodewhisperer.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+// dark
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)
+val Green80 = Color(0xFFA5D6A7)
+val Yellow80 = Color(0xFFFFF59D)
 
+// light
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+val Green40 = Color(0xFF43A047)
+val Yellow40 = Color(0xFFFDD835)

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/ui/theme/Theme.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/ui/theme/Theme.kt
@@ -9,33 +9,48 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+
+/**
+ * Provider for colors that are not in the standard material 3 theme.
+ */
+@Immutable
+data class CustomColorsPalette(
+    val successColor: Color = Color.Unspecified,
+    val warningColor: Color = Color.Unspecified
+)
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
     secondary = PurpleGrey80,
     tertiary = Pink80
 )
+private val DarkCustomColorsPalette = CustomColorsPalette(
+    successColor = Green80,
+    warningColor = Yellow80,
+)
 
 private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
     tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
 )
+private val LightCustomColorsPalette = CustomColorsPalette(
+    successColor = Green40,
+    warningColor = Yellow40,
+)
+
+// make colors usable in @Composable functions, see https://developer.android.com/develop/ui/compose/compositionlocal
+val LocalCustomColorsPalette = staticCompositionLocalOf { CustomColorsPalette() }
+
 
 @Composable
 fun NodeWhispererTheme(
@@ -62,9 +77,13 @@ fun NodeWhispererTheme(
         }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    val customPalette = if (darkTheme) DarkCustomColorsPalette else LightCustomColorsPalette
+
+    CompositionLocalProvider(LocalCustomColorsPalette provides customPalette) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content
+        )
+    }
 }

--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/ui/theme/Theme.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/ui/theme/Theme.kt
@@ -68,14 +68,6 @@ fun NodeWhispererTheme(
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
-    }
 
     val customPalette = if (darkTheme) DarkCustomColorsPalette else LightCustomColorsPalette
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_screen_background">#000</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="splash_screen_background">#fff</color>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
-    <color name="green_500">#4CAF50</color>
-    <color name="yellow_500">#FFEB3B</color>
-    <color name="red_500">#F44336</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="splash_screen_background">#fff</color>
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.NodeWhisperer" parent="android:Theme.Material.Light.NoActionBar" />
+    <!-- Styles that are only used while the app is initializing (i.e. splash screen) -->
+    <style name="Theme.NodeWhisperer" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">@color/splash_screen_background</item>
+    </style>
 </resources>


### PR DESCRIPTION
Commit 1 adresses:
- When you have dark mode enabled and open the app, you get a white splashscreen anyways which hurts your eyes

Commit 2 adresses:
- the colors for the scanning FAB and the status of the node (e.g. mesh only, ok, ...) were previously using the same colors in dark and light mode, making it look ugly. Also, we defined the colors via XML instead of using Jetpack Compose's theming abilities

Commit 3 adresses:
- enables edge to edge, as that's required by recent Android versions (https://developer.android.com/develop/ui/views/layout/edge-to-edge)
- this allows us to just let Android handle the status bar color, so it also fixes the current issue that in dark mode, the text of the status bar is black (so the contrast is just bad)

I can split this up into multiple PRs if required, but was too lazy because that would cause conflicts between my PRs.


Screenshots for commit 2 (I made them before doing commit 3, that's why the status bar is still wrong in the screenshots):
<img width="1080" height="2400" alt="dark" src="https://github.com/user-attachments/assets/b0dee7d1-4b3a-4416-bc61-5f55d6220043" />
<img width="1080" height="2400" alt="light" src="https://github.com/user-attachments/assets/08585eb1-40a3-46f8-938d-7dd5a88010ab" />
