### PR TITLE
fix: set receiverRegistered flag to true after registering

### DIFF
--- a/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
+++ b/app/src/main/java/net/freifunk/darmstadt/nodewhisperer/services/WifiScanService.kt
@@ -88,7 +88,7 @@ class WifiScanService(context: Context) {
             intentFilter.addAction(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION)
             context.registerReceiver(wifiScanReceiver, intentFilter)
 
-            receiverRegistered = false
+            receiverRegistered = true
         }
 
         scanningEnabled.value = true


### PR DESCRIPTION
The flag was incorrectly set to false after registerReceiver(), which caused stopScanning() to skip unregisterReceiver() and leak the broadcast receiver across scan sessions.